### PR TITLE
Fixes/Improvements to the SubstratumLauncher activity

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-Substratum Theme Template
+stt

--- a/.idea/dictionaries/Nicholas.xml
+++ b/.idea/dictionaries/Nicholas.xml
@@ -1,8 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="Nicholas">
-    <words>
-      <w>skippable</w>
-      <w>themers</w>
-    </words>
-  </dictionary>
-</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,6 +27,22 @@
       </value>
     </option>
   </component>
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State>
+            <id />
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>Android</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
     <OptionsSetting value="true" id="Remove" />
@@ -42,5 +58,21 @@
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
+  </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.8</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/SubstratumThemeTemplate.iml" filepath="$PROJECT_DIR$/SubstratumThemeTemplate.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/stt.iml" filepath="$PROJECT_DIR$/stt.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -160,9 +160,6 @@ If you have a completely white image, your actionbar and nav bar will change to 
 
 ## Step 5: Safeguard your theme! Don't let the pirates win!
 
-### DURING THEME DEBUGGING ON YOUR OWN PHONE
-While debugging your application, you should be setting this to false so that it doesn't keep triggering antipiracy when you are working: https://github.com/TeamSubstratum/SubstratumThemeTemplate/blob/master/app/src/main/java/substratum/theme/template/SubstratumLauncher.java#L34
-
 ### If you don't want to activate AntiPiracy
 Set this value to false and the antipiracy check will report back true to Substratum every time:
 https://github.com/TeamSubstratum/SubstratumThemeTemplate/blob/master/app/src/main/java/substratum/theme/template/SubstratumLauncher.java#L34

--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ Then you would need to go to Play Developer Console. Then access to your app -> 
 
 Finally, if you would like to change where it checks for piracy, you should just comment out the .enable lines such as if you would not like to have Amazon App Store piracy checking, just disable it below this line: https://github.com/TeamSubstratum/SubstratumThemeTemplate/blob/master/app/src/main/java/substratum/theme/template/SubstratumLauncher.java#L76
 
-# DO NOT SHARE YOUR SUBSTRATUMLAUNCHER.JAVA FILE IF YOU OPEN SOURCE YOUR THEME AND WANT TO KEEP PIRACY!
+# DO NOT SHARE YOUR SUBSTRATUMLAUNCHER.JAVA FILE IF YOU OPEN SOURCE YOUR THEME AND WANT TO KEEP ANTIPIRACY!

--- a/app/src/main/java/substratum/theme/template/SubstratumLauncher.java
+++ b/app/src/main/java/substratum/theme/template/SubstratumLauncher.java
@@ -73,8 +73,7 @@ public class SubstratumLauncher extends Activity {
                     public void dontAllow(PiracyCheckerError error) {
                         String parse = String.format(getString(R.string.toast_unlicensed),
                                 getString(R.string.ThemeName));
-                        Toast toast = Toast.makeText(getApplicationContext(), parse,
-                                Toast.LENGTH_SHORT);
+                        Toast toast = Toast.makeText(SubstratumLauncher.this, parse, Toast.LENGTH_SHORT);
                         toast.show();
                         finish();
                     }
@@ -134,10 +133,7 @@ public class SubstratumLauncher extends Activity {
                 "https://play.google.com/store/apps/details?" +
                         "id=projekt.substratum&hl=en";
         Intent i = new Intent(Intent.ACTION_VIEW);
-        Toast toast = Toast.makeText(getApplicationContext(),
-                getString(R.string
-                        .toast_substratum),
-                Toast.LENGTH_SHORT);
+        Toast toast = Toast.makeText(this, getString(R.string.toast_substratum), Toast.LENGTH_SHORT);
         toast.show();
         i.setData(Uri.parse(playURL));
         startActivity(i);
@@ -158,7 +154,7 @@ public class SubstratumLauncher extends Activity {
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra("theme_name", getString(R.string.ThemeName));
-        intent.putExtra("theme_pid", getApplicationContext().getPackageName());
+        intent.putExtra("theme_pid", getPackageName());
         intent.putExtra("theme_legacy", theme_legacy);
         intent.putExtra("theme_mode", theme_mode);
         intent.putExtra("refresh_mode", refresh_mode);

--- a/app/src/main/java/substratum/theme/template/SubstratumLauncher.java
+++ b/app/src/main/java/substratum/theme/template/SubstratumLauncher.java
@@ -2,8 +2,8 @@ package substratum.theme.template;
 
 import android.app.Activity;
 import android.content.ComponentName;
-import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -29,92 +29,44 @@ public class SubstratumLauncher extends Activity {
     //
     // TODO: Themers, this is your FIRST step
     // UNIVERSAL SWITCH: Control whether Anti-Piracy should be activated while testing
-    public static Boolean ENABLE_ANTI_PIRACY = false;
+    private static final boolean ENABLE_ANTI_PIRACY = false;
     // In order to retrieve your BASE64 license key your app must be uploaded to
     // Play Developer Console. Then access to your app -> Services and APIs.
     // You will need to replace "" with the code you obtained from the Play Developer Console.
-    // NOTE: THIS STEP IS SKIPPABLE, BUT YOU WILL NEED TO COMMENT OUT LINE 77!
+    // If ENABLE_ANTI_PIRACY is false, you may skip this
     // TODO: Themers, this is your SECOND step
-    private static String BASE_64_LICENSE_KEY = "";
+    private static final String BASE_64_LICENSE_KEY = "";
     // Build your signed APK using your signature, and run the app once in Substratum
     // (open your theme). Check your logcat!
     // You will need to do this only when submitting to Play. Locate "SubstratumAntiPiracyLog" and
     // head down to line 66. You will need to replace "" with the code you obtained from your
     // logcat.
-    // NOTE: THIS STEP IS SKIPPABLE, BUT YOU WILL NEED TO COMMENT OUT LINE 78!
+    // If ENABLE_ANTI_PIRACY is false, you may skip this
     // TODO: Themers, this is your THIRD step
-    private static String APK_SIGNATURE_PRODUCTION = "";
+    private static final String APK_SIGNATURE_PRODUCTION = "";
     //
     // END OF STATIC THEMER CRUISE CONTROL
 
-
-    private String theme_mode = "";  // SUBSTRATUM INTERNAL USE: DO NOT TOUCH
-
-    private static boolean isPackageInstalled(Context context, String package_name) {
-        PackageManager pm = context.getPackageManager();
-        try {
-            pm.getPackageInfo(package_name, PackageManager.GET_ACTIVITIES);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    private void startAntiPiracyCheck(final Boolean theme_legacy, final Boolean refresh_mode) {
+    private void startAntiPiracyCheck() {
         // TODO: Themers, this is your FOURTH step
         Log.e("SubstratumAntiPiracyLog", PiracyCheckerUtils.getAPKSignature(this));
         // COMMENT OUT THE ABOVE LINE ONCE YOU OBTAINED YOUR APK SIGNATURE USING
         // TWO DASHES (LIKE THIS EXACT LINE)
 
-        new PiracyChecker(this)
+        PiracyChecker piracyChecker = new PiracyChecker(this)
 
                 // TODO: Themers, this is your FINAL step
                 // To disable certain piracy features, comment it out so that it doesn't
                 // trigger anti-piracy.
                 .enableInstallerId(InstallerID.GOOGLE_PLAY)
                 //.enableInstallerId(InstallerID.AMAZON_APP_STORE)
-                .enableGooglePlayLicensing(BASE_64_LICENSE_KEY)
-                .enableSigningCertificate(APK_SIGNATURE_PRODUCTION)
                 // END OF THEMER TOUCHABLE OPTIONS
                 // TO RETAIN INTEGRITY, PLEASE DO NOT MODIFY ANY OTHER LINES
 
                 .callback(new PiracyCheckerCallback() {
                     @Override
                     public void allow() {
-                        // If Substratum is found, then launch it with specific parameters
-                        Intent launchIntent = new Intent("projekt.substratum");
-                        if (isPackageInstalled(getApplicationContext(),
-                                "projekt.substratum") && launchIntent != null) {
-                            // Substratum is found, launch it directly
-                            Intent intent = new Intent(Intent.ACTION_MAIN);
-                            intent.setComponent(ComponentName.unflattenFromString(
-                                    "projekt.substratum/projekt.substratum" +
-                                            ".InformationActivity"));
-                            intent.addCategory(Intent.CATEGORY_LAUNCHER);
-                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                            intent.putExtra("theme_name", getString(R.string.ThemeName));
-                            intent.putExtra("theme_pid", getApplicationContext()
-                                    .getPackageName());
-                            intent.putExtra("theme_legacy", theme_legacy);
-                            intent.putExtra("theme_mode", theme_mode);
-                            intent.putExtra("refresh_mode", refresh_mode);
-                            startActivity(intent);
-                            finish();
-                        } else {
-                            String playURL =
-                                    "https://play.google.com/store/apps/details?" +
-                                            "id=projekt.substratum&hl=en";
-                            Intent i = new Intent(Intent.ACTION_VIEW);
-                            Toast toast = Toast.makeText(getApplicationContext(),
-                                    getString(R.string
-                                            .toast_substratum),
-                                    Toast.LENGTH_SHORT);
-                            toast.show();
-                            i.setData(Uri.parse(playURL));
-                            startActivity(i);
-                            finish();
-                        }
+                        beginSubstratumLaunch();
                     }
 
                     @Override
@@ -126,60 +78,101 @@ public class SubstratumLauncher extends Activity {
                         toast.show();
                         finish();
                     }
-                })
-                .start();
+                });
+
+        if (BASE_64_LICENSE_KEY.length() > 0) {
+            piracyChecker.enableGooglePlayLicensing(BASE_64_LICENSE_KEY);
+        }
+        if (APK_SIGNATURE_PRODUCTION.length() > 0) {
+            piracyChecker.enableSigningCertificate(APK_SIGNATURE_PRODUCTION);
+        }
+        piracyChecker.start();
+    }
+
+    /**
+     * Other variables/methods; do not modify
+     */
+
+    private static final String PROJEKT_SUBSTRATUM = "projekt.substratum";
+
+    private boolean isPackageInstalled(String package_name) {
+        PackageManager pm = getPackageManager();
+        try {
+            pm.getPackageInfo(package_name, PackageManager.GET_ACTIVITIES);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean isPackageEnabled(String package_name) {
+        try {
+            ApplicationInfo ai = getPackageManager().getApplicationInfo(package_name, 0);
+            return ai.enabled;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private void beginSubstratumLaunch() {
+        // If Substratum is found, then launch it with specific parameters
+        if (isPackageInstalled(PROJEKT_SUBSTRATUM)) {
+            if (!isPackageEnabled(PROJEKT_SUBSTRATUM)) {
+                //TODO tell user to enable/defrost app
+                return;
+            }
+            // Substratum is found, launch it directly
+            launchSubstratum();
+        } else {
+            getSubstratumFromPlayStore();
+        }
+    }
+
+    private void getSubstratumFromPlayStore() {
+        String playURL =
+                "https://play.google.com/store/apps/details?" +
+                        "id=projekt.substratum&hl=en";
+        Intent i = new Intent(Intent.ACTION_VIEW);
+        Toast toast = Toast.makeText(getApplicationContext(),
+                getString(R.string
+                        .toast_substratum),
+                Toast.LENGTH_SHORT);
+        toast.show();
+        i.setData(Uri.parse(playURL));
+        startActivity(i);
+        finish();
+    }
+
+    private void launchSubstratum() {
+        Intent currentIntent = getIntent();
+        String theme_mode = currentIntent.getStringExtra("theme_mode");
+        if (theme_mode == null) theme_mode = "";
+        final boolean theme_legacy = currentIntent.getBooleanExtra("theme_legacy", false);
+        final boolean refresh_mode = currentIntent.getBooleanExtra("refresh_mode", false);
+
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.setComponent(ComponentName.unflattenFromString(
+                "projekt.substratum/projekt.substratum.InformationActivity"));
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra("theme_name", getString(R.string.ThemeName));
+        intent.putExtra("theme_pid", getApplicationContext().getPackageName());
+        intent.putExtra("theme_legacy", theme_legacy);
+        intent.putExtra("theme_mode", theme_mode);
+        intent.putExtra("refresh_mode", refresh_mode);
+        startActivity(intent);
+        finish();
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        Boolean is_substratum_installed = isPackageInstalled(getApplicationContext(),
-                "projekt.substratum");
-
-        if (is_substratum_installed) {
-            Intent currentIntent = getIntent();
-            theme_mode = currentIntent.getStringExtra("theme_mode");
-            final Boolean theme_legacy = currentIntent.getBooleanExtra("theme_legacy", false);
-            final Boolean refresh_mode = currentIntent.getBooleanExtra("refresh_mode", false);
-            if (theme_mode == null) {
-                theme_mode = "";
-            }
-            if (ENABLE_ANTI_PIRACY) {
-                startAntiPiracyCheck(theme_legacy, refresh_mode);
-            } else {
-                // If Substratum is found, then launch it with specific parameters
-                Intent launchIntent = new Intent("projekt.substratum");
-                if (launchIntent != null) {
-                    // Substratum is found, launch it directly
-                    Intent intent = new Intent(Intent.ACTION_MAIN);
-                    intent.setComponent(ComponentName.unflattenFromString(
-                            "projekt.substratum/projekt.substratum.InformationActivity"));
-                    intent.addCategory(Intent.CATEGORY_LAUNCHER);
-                    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                    intent.putExtra("theme_name", getString(R.string.ThemeName));
-                    intent.putExtra("theme_pid", getApplicationContext().getPackageName());
-                    intent.putExtra("theme_legacy", theme_legacy);
-                    intent.putExtra("theme_mode", theme_mode);
-                    intent.putExtra("refresh_mode", refresh_mode);
-                    startActivity(intent);
-                    finish();
-                }
-            }
+        if (ENABLE_ANTI_PIRACY && !BuildConfig.DEBUG) {
+            startAntiPiracyCheck();
         } else {
-            String playURL =
-                    "https://play.google.com/store/apps/details?" +
-                            "id=projekt.substratum&hl=en";
-            Intent i = new Intent(Intent.ACTION_VIEW);
-            Toast toast = Toast.makeText(getApplicationContext(),
-                    getString(R.string
-                            .toast_substratum),
-                    Toast.LENGTH_SHORT);
-            toast.show();
-            i.setData(Uri.parse(playURL));
-            startActivity(i);
-            finish();
+            beginSubstratumLaunch();
         }
     }
 }


### PR DESCRIPTION
1. My changes were untested; I have yet to make a substratum theme
2. You should gitignore all the idea files; as you can see with my commit, those files change as soon as someone else imports and pushes the changes.
3. I added a TODO to check if substratum is enabled (not frozen). Frozen/disabled apps are installed but will crash when you attempt to launch them.

My changes
- Add DEBUG checker to disable privacy checks in debug mode automatically
- Only add license and signature checks when the keys are added; no need to comment out new lines
- Remove intents that were always nonnull
- Remove application context usages to activity context
- Change Boolean to boolean
- Added methods so duplicate functions are only written once
- Removed shared variables that didn't need to be shared. Only retrieve intent extras when you need it.
