### PR TITLE
Correct Material Light theme for ThemeReady AlertDialog

### DIFF
--- a/app/src/main/java/substratum/theme/template/SubstratumLauncher.java
+++ b/app/src/main/java/substratum/theme/template/SubstratumLauncher.java
@@ -245,7 +245,8 @@ public class SubstratumLauncher extends Activity {
                 String parse = String.format(getString(R.string.theme_ready_updated),
                         app_name);
 
-                new AlertDialog.Builder(SubstratumLauncher.this)
+                new AlertDialog.Builder(SubstratumLauncher.this, android.R.style
+                        .Theme_DeviceDefault_Light_Dialog_Alert)
                         .setIcon(R.mipmap.ic_launcher)
                         .setTitle(getString(R.string.ThemeName))
                         .setMessage(parse)
@@ -268,7 +269,8 @@ public class SubstratumLauncher extends Activity {
                         .show();
             }
         } else {
-            new AlertDialog.Builder(SubstratumLauncher.this)
+            new AlertDialog.Builder(SubstratumLauncher.this, android.R.style
+                    .Theme_DeviceDefault_Light_Dialog_Alert)
                     .setIcon(R.mipmap.ic_launcher)
                     .setTitle(getString(R.string.ThemeName))
                     .setMessage(getString(R.string.theme_ready_not_detected))


### PR DESCRIPTION
This is untested, but I think I followed the Android Developer docs correctly:
https://developer.android.com/reference/android/app/AlertDialog.Builder.html

also, similar working commit:
https://github.com/nicholaschum/substratum/commit/d1ad332b0b69b11a383bf093d68b403725080964