### PR TITLE
SubstratumLauncher: Fix build breakage caused by extra brace

### DIFF
--- a/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt
+++ b/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt
@@ -213,8 +213,6 @@ class SubstratumLauncher : Activity() {
             val packageManager = this.packageManager
             val app_name = StringBuilder()
 
-            }
-
             if (!incomplete) {
                 for (packageName in THEME_READY_PACKAGES) {
                     try {


### PR DESCRIPTION
The errors below occured because of the additional brace that closed off the entire
if block too early, which made all the variables inside the if block outside the scope
of the rest of the code, causing all variable calls to throw unresolved reference errors.

e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (260, 11): Expecting member declaration
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (260, 16): Expecting member declaration
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (271, 1): Expecting a top level declaration
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (218, 18): Unresolved reference: incomplete
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (223, 29): Unresolved reference: updated
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (224, 29): Unresolved reference: apps
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (232, 23): Unresolved reference: apps
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (233, 17): Unresolved reference: app_name
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (233, 33): Unresolved reference: apps
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (234, 26): Unresolved reference: apps
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (235, 21): Unresolved reference: app_name
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (236, 33): Unresolved reference: apps
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (237, 21): Unresolved reference: app_name
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (241, 18): Unresolved reference: updated
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (241, 30): Unresolved reference: incomplete
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (244, 37): Unresolved reference: incomplete
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (249, 25): Unresolved reference: app_name
e: /home/msfjarvis/git-repos/Greyce-Substratum/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt: (260, 16): Function declaration must have a name