### PR TITLE
Remove closing brace

### DIFF
--- a/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt
+++ b/app/src/main/java/substratum/theme/template/SubstratumLauncher.kt
@@ -213,8 +213,6 @@ class SubstratumLauncher : Activity() {
             val packageManager = this.packageManager
             val app_name = StringBuilder()
 
-            }
-
             if (!incomplete) {
                 for (packageName in THEME_READY_PACKAGES) {
                     try {


### PR DESCRIPTION
Remove closing brace left behind on Line #216 in SubstratumLauncher.kt left behind after https://github.com/substratum/template/commit/1f9ae5a