### PR TITLE
[WiP] Move all variables to gradle file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ app/release/output\.json
 # C++
 #############################################################################
 app/.externalNativeBuild
+
+GeneratedInformation.h

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,18 +5,11 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
+apply from: 'variables.gradle'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 ext {
-    // Whether the theme assets should be encrypted or not,
-    // this makes it harder for pirates and kangers! (DEFAULT: true)
-    SHOULD_ENCRYPT_ASSETS = true
-
-    // Whether this theme supports third party theme systems, we will not be able to help you debug
-    // your themes on external theming systems, so the team will NOT respond to external systems if
-    // there are issues with your theme (DEFAULT: false)
-    SUPPORTS_THIRD_PARTY_SYSTEMS = false
 
     // Encryption values, do not touch as we generate a random key every time you compile!
     byte[] key = new byte[16]
@@ -153,13 +146,53 @@ task encryptAssets {
         throw new RuntimeException("Old temporary assets found! Try and do a clean project.")
     }
 }
+/*
+
+static def CBool(boolean b) {
+    if (b) {
+        return "JNI_TRUE"
+    } else {
+        return "JNI_FALSE"
+    }
+}
+*/
+
+ext.CBool = {b ->
+    return b ? "JNI_TRUE" : "JNI_FALSE"
+}
+
+task generatedInformationH {
+
+    def file = new File(getProjectDir(), "src/main/jni/GeneratedInformation.h")
+
+    def fileContent = """
+#include <jni.h>
+
+#define ENABLE_ANTIPIRACY ${CBool(ENABLE_ANTIPIRACY)}
+#define BASE64_LICENSE_KEY "${BASE64_LICENSE_KEY}"
+#define APK_SIGNATURE "${APK_SIGNATURE}"
+#define INTERNET_CHECK ${CBool(INTERNET_CHECK)}
+#define ENFORCE_GOOGLE_PLAY_INSTALL ${CBool(ENFORCE_GOOGLE_PLAY_INSTALL)}
+#define ENFORCE_AMAZON_APP_INSTALL ${CBool(ENFORCE_AMAZON_APP_INSTALL)}
+#define ENFORCE_BLACKLISTED_APKS_CHECK ${CBool(ENFORCE_BLACKLISTED_APKS_CHECK)}
+#define ALLOW_THIRD_PARTY_SUBSTRATUM_BUILD ${CBool(ALLOW_THIRD_PARTY_SUBSTRATUM_BUILD)}
+"""
+
+    if (file.exists()) {
+        file.delete()
+    }
+
+    file << fileContent
+
+
+}
 
 project.afterEvaluate {
-    preBuild.dependsOn encryptAssets
+    preBuild.dependsOn(generatedInformationH, encryptAssets)
 }
 
 gradle.buildFinished {
-    def tempAssets = new File(getProjectDir(), "/src/main/assets-temp")
+    def tempAssets = new File(getProjectDir(), "src/main/assets-temp")
     if (tempAssets.exists()) {
         println("Cleaning duplicated encrypted assets, not your decrypted assets...")
         def encryptedAssets = new File(getProjectDir(), "src/main/assets")

--- a/app/src/main/jni/LoadingProcess.c
+++ b/app/src/main/jni/LoadingProcess.c
@@ -1,4 +1,5 @@
 #include <jni.h>
+#include "GeneratedInformation.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -9,34 +10,27 @@
  */
 JNIEXPORT jboolean JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getAPStatus(JNIEnv *env) {
-    return JNI_FALSE;
+    return ENABLE_ANTIPIRACY;
 }
 
 /*
  * Base 64 License Key
  *
- * Insert your base 64 license key obtained from Play Store in the quotations below!
- * ATTENTION: On line 23, do you see the "000"? You MUST count the amount of characters of your key
- * and input the proper number! This is so that you get your own specialized set of variables!
  */
 JNIEXPORT jstring JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getBase64Key(JNIEnv *env) {
-    // TODO: This must be done!
-    char BASE_64_LICENSE_KEY[000] = "";
-    return (*env)->NewStringUTF(env, BASE_64_LICENSE_KEY);
+    return (*env)->NewStringUTF(env, BASE64_LICENSE_KEY);
 }
 
 /*
  * APK Signature Production
  *
  * Insert your release APK's signature in the quotations below!
- * ATTENTION: On line 34, do you see the "28"? If you're disabling antipiracy, change that to 0!
  * All release production signature prefixes have the length of 28!
  */
 JNIEXPORT jstring JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getAPKSignatureProduction(JNIEnv *env) {
-    char APK_SIGNATURE_PRODUCTION[28] = "";
-    return (*env)->NewStringUTF(env, APK_SIGNATURE_PRODUCTION);
+    return (*env)->NewStringUTF(env, APK_SIGNATURE);
 }
 
 /*
@@ -46,7 +40,7 @@ Java_substratum_theme_template_SubstratumLauncher_getAPKSignatureProduction(JNIE
  */
 JNIEXPORT jboolean JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getInternetCheck(JNIEnv *env) {
-    return JNI_FALSE;
+    return INTERNET_CHECK;
 }
 
 /*
@@ -56,7 +50,7 @@ Java_substratum_theme_template_SubstratumLauncher_getInternetCheck(JNIEnv *env) 
  */
 JNIEXPORT jboolean JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getGooglePlayRequirement(JNIEnv *env) {
-    return JNI_FALSE;
+    return ENFORCE_GOOGLE_PLAY_INSTALL;
 }
 
 /*
@@ -66,7 +60,7 @@ Java_substratum_theme_template_SubstratumLauncher_getGooglePlayRequirement(JNIEn
  */
 JNIEXPORT jboolean JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getAmazonAppStoreRequirement(JNIEnv *env) {
-    return JNI_FALSE;
+    return ENFORCE_AMAZON_APP_INSTALL;
 }
 
 /*
@@ -76,7 +70,7 @@ Java_substratum_theme_template_SubstratumLauncher_getAmazonAppStoreRequirement(J
  */
 JNIEXPORT jboolean JNICALL
 Java_substratum_theme_template_SubstratumLauncher_getBlacklistedApplications(JNIEnv *env) {
-    return JNI_FALSE;
+    return ENFORCE_BLACKLISTED_APKS_CHECK;
 }
 
 /*
@@ -91,7 +85,7 @@ Java_substratum_theme_template_SubstratumLauncher_getBlacklistedApplications(JNI
  */
 JNIEXPORT jboolean JNICALL
 Java_substratum_theme_template_SubstratumLauncher_allowThirdPartySubstratumBuilds(JNIEnv *env) {
-    return JNI_TRUE;
+    return ALLOW_THIRD_PARTY_SUBSTRATUM_BUILD;
 }
 
 /*

--- a/app/variables.gradle
+++ b/app/variables.gradle
@@ -1,0 +1,80 @@
+ext {
+
+    //THEMERS EDIT STARTS HERE
+
+    // Whether the theme assets should be encrypted or not,
+    // this makes it harder for pirates and kangers! (DEFAULT: true)
+    SHOULD_ENCRYPT_ASSETS = true
+
+    // Whether this theme supports third party theme systems, we will not be able to help you debug
+    // your themes on external theming systems, so the team will NOT respond to external systems if
+    // there are issues with your theme (DEFAULT: false)
+    SUPPORTS_THIRD_PARTY_SYSTEMS = false
+
+    //Whenever to enable antipiracy measures (DEFAULT: true)
+    ENABLE_ANTIPIRACY = true
+
+    /*
+     * Base 64 License Key
+     *
+     * Insert your base 64 license key obtained from Play Store in the quotations below!
+     */
+    BASE64_LICENSE_KEY = ""
+
+    /*
+     * APK Signature Production
+     *
+     * Insert your release APK's signature in the quotations below!
+     * All release production signature prefixes have the length of 28!
+     */
+    APK_SIGNATURE = ""
+
+    /*
+     * Enforce Internet Check
+     *
+     * Change this value to true if you would like to enable internet check
+     */
+    INTERNET_CHECK = false
+
+    /*
+     * Enforce Google Play Install
+     *
+     * Change this value to true if you would like to enable this check
+     */
+    ENFORCE_GOOGLE_PLAY_INSTALL = false
+
+
+    /*
+     * Enforce Amazon App Store Install
+     *
+     * Change this value to JNI_TRUE if you would like to enable this check
+     */
+    ENFORCE_AMAZON_APP_INSTALL = false
+
+
+    /*
+     * Enable check for Blacklisted APKs
+     *
+     * Change this value to JNI_TRUE if you would like to enable blacklist check
+     */
+    ENFORCE_BLACKLISTED_APKS_CHECK = false
+
+    /*
+     * Allow Third Party Substratum Builds
+     *
+     * Change this value to JNI_FALSE if you would like to ban your theme to work on external, non-team
+     * built compilations of substratum
+     *
+     * WARNING: Having this enabled may or may not cause a bunch of issues due to the system not built
+     *          and distributed by an official team member. You will take charge of handling bug reports
+     *          if there are specific bugs unreproducible on the main stream of APKs.
+     */
+    ALLOW_THIRD_PARTY_SUBSTRATUM_BUILD = true
+
+    //THEMERS EDIT ENDS HERE
+
+    if(APK_SIGNATURE && APK_SIGNATURE.length() != 28) {
+        throw new RuntimeException("APK_SIGNATURE must be either empty or have 28 characters")
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Themers shouldn't care if plugin is written in Java, Kotlin, C++ or Brainfuck. They just need simple way to include their's theme data. Do make it easier let's make new file `variables.gradle` where thety could enter this data and files for Java and C will be generated from it.

Before merging this PR should be checked and accepted by themers.